### PR TITLE
Use Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dj-library-gain-calculator"
 version = "0.1.0"
 authors = ["Raphaël Lustin <raphael@lustin.fr>"]
+edition = "2018"
 
 [dependencies]
 audrey = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dj-library-gain-calculator"
 version = "0.1.0"
-authors = ["Raphaël Lustin <raphael@lustin.fr>"]
+authors = ["Paul Adenot <paul@paul.cx>", "Raphaël Lustin <raphael@lustin.fr>"]
 edition = "2018"
 
 [dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ pub enum AppError {
 }
 
 impl std::fmt::Display for AppError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
             AppError::GenericError(ref message) => f.write_str(message),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,3 @@
-extern crate clap;
-extern crate minimp3;
-extern crate quick_xml;
-extern crate rayon;
-extern crate serde;
-
 use clap::{load_yaml, App};
 use crate::traktor::parse_traktor_collection;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ extern crate rayon;
 extern crate serde;
 
 use clap::{load_yaml, App};
-use traktor::parse_traktor_collection;
+use crate::traktor::parse_traktor_collection;
 
 mod error;
 mod models;

--- a/src/traktor/mod.rs
+++ b/src/traktor/mod.rs
@@ -1,5 +1,5 @@
-use error::AppError;
-use models::Nml;
+use crate::error::AppError;
+use crate::models::Nml;
 use quick_xml::de::from_reader;
 use std::fs::File;
 use std::io::BufReader;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,3 @@
-extern crate assert_cmd;
-
 use assert_cmd::prelude::*;
 use std::process::Command;
 


### PR DESCRIPTION
The main benefit for now is to not have to put in `extern crate ...`, but changes are generally super nice and https://doc.rust-lang.org/edition-guide/rust-2018/index.html has all the info.